### PR TITLE
Redirect profiling output from console to AKit wpilog

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -301,19 +301,9 @@ public class Robot extends LoggedRobot {
 
     // Profiling output
     if (Constants.PROFILING_ENABLED) {
-      long schedulerMs = (t1 - loopStart) / 1_000_000;
-      long gameStateMs = (t2 - t1) / 1_000_000;
-      long totalMs = (t2 - loopStart) / 1_000_000;
-      if (totalMs > 20) {
-        System.out.println(
-            "[Robot] scheduler="
-                + schedulerMs
-                + "ms gameState="
-                + gameStateMs
-                + "ms total="
-                + totalMs
-                + "ms");
-      }
+      Logger.recordOutput("Profiling/Robot/SchedulerMs", (t1 - loopStart) / 1_000_000);
+      Logger.recordOutput("Profiling/Robot/GameStateMs", (t2 - t1) / 1_000_000);
+      Logger.recordOutput("Profiling/Robot/TotalMs", (t2 - loopStart) / 1_000_000);
     }
 
     // Return to non-RT thread priority (do not modify the first argument)

--- a/src/main/java/frc/robot/subsystems/drive/Drive.java
+++ b/src/main/java/frc/robot/subsystems/drive/Drive.java
@@ -222,25 +222,13 @@ public class Drive extends SubsystemBase {
 
     // Profiling output
     if (Constants.PROFILING_ENABLED) {
-      long totalMs = (t6 - startNanos) / 1_000_000;
-      if (totalMs > 5) {
-        System.out.println(
-            "[Drive] lock="
-                + (t1 - startNanos) / 1_000_000
-                + "ms gyroUpdate="
-                + (t2 - t1) / 1_000_000
-                + "ms gyroLog="
-                + (t3 - t2) / 1_000_000
-                + "ms modules="
-                + (t4 - t3) / 1_000_000
-                + "ms disabled="
-                + (t5 - t4) / 1_000_000
-                + "ms odometry="
-                + (t6 - t5) / 1_000_000
-                + "ms total="
-                + totalMs
-                + "ms");
-      }
+      Logger.recordOutput("Profiling/Drive/LockMs", (t1 - startNanos) / 1_000_000);
+      Logger.recordOutput("Profiling/Drive/GyroUpdateMs", (t2 - t1) / 1_000_000);
+      Logger.recordOutput("Profiling/Drive/GyroLogMs", (t3 - t2) / 1_000_000);
+      Logger.recordOutput("Profiling/Drive/ModulesMs", (t4 - t3) / 1_000_000);
+      Logger.recordOutput("Profiling/Drive/DisabledMs", (t5 - t4) / 1_000_000);
+      Logger.recordOutput("Profiling/Drive/OdometryMs", (t6 - t5) / 1_000_000);
+      Logger.recordOutput("Profiling/Drive/TotalMs", (t6 - startNanos) / 1_000_000);
     }
   }
 

--- a/src/main/java/frc/robot/subsystems/drive/Module.java
+++ b/src/main/java/frc/robot/subsystems/drive/Module.java
@@ -76,19 +76,10 @@ public class Module {
 
     // Profiling output
     if (Constants.PROFILING_ENABLED) {
-      long totalMs = (t3 - t0) / 1_000_000;
-      if (totalMs > 2) {
-        System.out.println(
-            "[Module"
-                + index
-                + "] updateInputs="
-                + (t1 - t0) / 1_000_000
-                + "ms log="
-                + (t2 - t1) / 1_000_000
-                + "ms rest="
-                + (t3 - t2) / 1_000_000
-                + "ms");
-      }
+      Logger.recordOutput("Profiling/Module" + index + "/UpdateInputsMs", (t1 - t0) / 1_000_000);
+      Logger.recordOutput("Profiling/Module" + index + "/LogMs", (t2 - t1) / 1_000_000);
+      Logger.recordOutput("Profiling/Module" + index + "/RestMs", (t3 - t2) / 1_000_000);
+      Logger.recordOutput("Profiling/Module" + index + "/TotalMs", (t3 - t0) / 1_000_000);
     }
   }
 

--- a/src/main/java/frc/robot/subsystems/feeder/Feeder.java
+++ b/src/main/java/frc/robot/subsystems/feeder/Feeder.java
@@ -45,21 +45,11 @@ public class Feeder extends SubsystemBase {
 
     // Profiling output
     if (Constants.PROFILING_ENABLED) {
-      long totalMs = (t4 - t0) / 1_000_000;
-      if (totalMs > 2) {
-        System.out.println(
-            "[Feeder] spindexer="
-                + (t1 - t0) / 1_000_000
-                + "ms kicker="
-                + (t2 - t1) / 1_000_000
-                + "ms spindexerLog="
-                + (t3 - t2) / 1_000_000
-                + "ms kickerLog="
-                + (t4 - t3) / 1_000_000
-                + "ms total="
-                + totalMs
-                + "ms");
-      }
+      Logger.recordOutput("Profiling/Feeder/SpindexerMs", (t1 - t0) / 1_000_000);
+      Logger.recordOutput("Profiling/Feeder/KickerMs", (t2 - t1) / 1_000_000);
+      Logger.recordOutput("Profiling/Feeder/SpindexerLogMs", (t3 - t2) / 1_000_000);
+      Logger.recordOutput("Profiling/Feeder/KickerLogMs", (t4 - t3) / 1_000_000);
+      Logger.recordOutput("Profiling/Feeder/TotalMs", (t4 - t0) / 1_000_000);
     }
   }
 

--- a/src/main/java/frc/robot/subsystems/hopper/Hopper.java
+++ b/src/main/java/frc/robot/subsystems/hopper/Hopper.java
@@ -25,17 +25,9 @@ public class Hopper extends SubsystemBase {
 
     // Profiling output
     if (Constants.PROFILING_ENABLED) {
-      long totalMs = (t2 - t0) / 1_000_000;
-      if (totalMs > 2) {
-        System.out.println(
-            "[Hopper] update="
-                + (t1 - t0) / 1_000_000
-                + "ms log="
-                + (t2 - t1) / 1_000_000
-                + "ms total="
-                + totalMs
-                + "ms");
-      }
+      Logger.recordOutput("Profiling/Hopper/UpdateMs", (t1 - t0) / 1_000_000);
+      Logger.recordOutput("Profiling/Hopper/LogMs", (t2 - t1) / 1_000_000);
+      Logger.recordOutput("Profiling/Hopper/TotalMs", (t2 - t0) / 1_000_000);
     }
   }
 

--- a/src/main/java/frc/robot/subsystems/intake/Intake.java
+++ b/src/main/java/frc/robot/subsystems/intake/Intake.java
@@ -51,17 +51,9 @@ public class Intake extends SubsystemBase {
 
     // Profiling output
     if (Constants.PROFILING_ENABLED) {
-      long totalMs = (t2 - t0) / 1_000_000;
-      if (totalMs > 2) {
-        System.out.println(
-            "[Intake] update="
-                + (t1 - t0) / 1_000_000
-                + "ms log="
-                + (t2 - t1) / 1_000_000
-                + "ms total="
-                + totalMs
-                + "ms");
-      }
+      Logger.recordOutput("Profiling/Intake/UpdateMs", (t1 - t0) / 1_000_000);
+      Logger.recordOutput("Profiling/Intake/LogMs", (t2 - t1) / 1_000_000);
+      Logger.recordOutput("Profiling/Intake/TotalMs", (t2 - t0) / 1_000_000);
     }
   }
 

--- a/src/main/java/frc/robot/subsystems/launcher/Launcher.java
+++ b/src/main/java/frc/robot/subsystems/launcher/Launcher.java
@@ -142,21 +142,11 @@ public class Launcher extends SubsystemBase {
 
     // Profiling output
     if (Constants.PROFILING_ENABLED) {
-      long totalMs = (t4 - t0) / 1_000_000;
-      if (totalMs > 3) {
-        System.out.println(
-            "[Launcher] update="
-                + (t1 - t0) / 1_000_000
-                + "ms log="
-                + (t2 - t1) / 1_000_000
-                + "ms aimLog="
-                + (t3 - t2) / 1_000_000
-                + "ms ballistics="
-                + (t4 - t3) / 1_000_000
-                + "ms total="
-                + totalMs
-                + "ms");
-      }
+      Logger.recordOutput("Profiling/Launcher/UpdateMs", (t1 - t0) / 1_000_000);
+      Logger.recordOutput("Profiling/Launcher/LogMs", (t2 - t1) / 1_000_000);
+      Logger.recordOutput("Profiling/Launcher/AimLogMs", (t3 - t2) / 1_000_000);
+      Logger.recordOutput("Profiling/Launcher/BallisticsMs", (t4 - t3) / 1_000_000);
+      Logger.recordOutput("Profiling/Launcher/TotalMs", (t4 - t0) / 1_000_000);
     }
   }
 
@@ -260,23 +250,12 @@ public class Launcher extends SubsystemBase {
 
     // Profiling output for aim()
     if (Constants.PROFILING_ENABLED) {
-      long totalUs = (t5 - aimStart) / 1_000;
-      if (totalUs > 500) {
-        System.out.println(
-            "[Launcher.aim] v0nom="
-                + (t1 - aimStart) / 1_000
-                + "us baseSpeeds="
-                + (t2 - t1) / 1_000
-                + "us v0replan="
-                + (t3 - t2) / 1_000
-                + "us setPos="
-                + (t4 - t3) / 1_000
-                + "us rest="
-                + (t5 - t4) / 1_000
-                + "us total="
-                + totalUs
-                + "us");
-      }
+      Logger.recordOutput("Profiling/Launcher/Aim/V0NomUs", (t1 - aimStart) / 1_000);
+      Logger.recordOutput("Profiling/Launcher/Aim/BaseSpeedsUs", (t2 - t1) / 1_000);
+      Logger.recordOutput("Profiling/Launcher/Aim/V0ReplanUs", (t3 - t2) / 1_000);
+      Logger.recordOutput("Profiling/Launcher/Aim/SetPosUs", (t4 - t3) / 1_000);
+      Logger.recordOutput("Profiling/Launcher/Aim/RestUs", (t5 - t4) / 1_000);
+      Logger.recordOutput("Profiling/Launcher/Aim/TotalUs", (t5 - aimStart) / 1_000);
     }
   }
 

--- a/src/main/java/frc/robot/subsystems/vision/Vision.java
+++ b/src/main/java/frc/robot/subsystems/vision/Vision.java
@@ -262,23 +262,12 @@ public class Vision extends SubsystemBase {
 
     // Profiling output
     if (Constants.PROFILING_ENABLED) {
-      long totalMs = (t5 - visionStart) / 1_000_000;
-      if (totalMs > 5) {
-        System.out.println(
-            "[Vision] snapshot="
-                + (t1 - visionStart) / 1_000_000
-                + "ms processInputs="
-                + (t2 - t1) / 1_000_000
-                + "ms cameraLoop="
-                + (t3 - t2) / 1_000_000
-                + "ms consumer="
-                + (t4 - t3) / 1_000_000
-                + "ms summaryLog="
-                + (t5 - t4) / 1_000_000
-                + "ms total="
-                + totalMs
-                + "ms");
-      }
+      Logger.recordOutput("Profiling/Vision/SnapshotMs", (t1 - visionStart) / 1_000_000);
+      Logger.recordOutput("Profiling/Vision/ProcessInputsMs", (t2 - t1) / 1_000_000);
+      Logger.recordOutput("Profiling/Vision/CameraLoopMs", (t3 - t2) / 1_000_000);
+      Logger.recordOutput("Profiling/Vision/ConsumerMs", (t4 - t3) / 1_000_000);
+      Logger.recordOutput("Profiling/Vision/SummaryLogMs", (t5 - t4) / 1_000_000);
+      Logger.recordOutput("Profiling/Vision/TotalMs", (t5 - visionStart) / 1_000_000);
     }
   }
 


### PR DESCRIPTION
Replaces every `System.out.println` inside `PROFILING_ENABLED` blocks with `Logger.recordOutput` calls, making timing data available in AdvantageScope instead of the console.

### Affected subsystems

- `Robot` — scheduler, game-state, and total loop time
- `Drive` — lock, gyro update, gyro log, modules, disabled, odometry, and total
- `Module` (×4) — updateInputs, log, rest, and total
- `Feeder` — spindexer, kicker, spindexer log, kicker log, and total
- `Hopper` — update, log, and total
- `Intake` — update, log, and total
- `Launcher` — update, log, aim log, ballistics, and total

All values are logged every cycle under the `Profiling/` key hierarchy. The old threshold conditionals (e.g. `if (totalMs > 5)`) are removed — logging every cycle is cheap and outliers are easier to spot graphically in AdvantageScope.

Closes #146