### PR TITLE
Increase chassis max angular acceleration in teleop

### DIFF
--- a/src/main/java/frc/robot/subsystems/drive/DriveConstants.java
+++ b/src/main/java/frc/robot/subsystems/drive/DriveConstants.java
@@ -90,7 +90,7 @@ public class DriveConstants {
   public static final AngularVelocity maxChassisAngularVelocity =
       RadiansPerSecond.of(maxChassisVelocity.in(MetersPerSecond) / driveBaseRadius.in(Meters));
   public static final AngularAcceleration maxChassisAngularAcceleration =
-      RadiansPerSecondPerSecond.of(4 * Math.PI);
+      RadiansPerSecondPerSecond.of(30);
 
   public static final PathConstraints pathFollowingConstraints =
       new PathConstraints(


### PR DESCRIPTION
Key findings:

- Massive headroom during angular acceleration: Supply current peaks at ~15A per motor against the 60A limit — only 25% utilized. Stator peaks at ~50A against 100A — 50% utilized.
- Steady rotation costs almost nothing: At 5.76 rad/s, supply current drops to <5A per motor. The motors are barely working to maintain speed.
- Direction reversal approaches stator limit: The hardest case — full direction reversal at peak speed — pushes Module0 stator to ~70A. Still 30% below the 100A stator limit, and supply current is near zero (regenerating into the bus).
- Translation is the binding constraint, not rotation: The 222A and 180A PDH peaks both occurred during near-zero angular velocity.


Conclusion: There is substantial room to increase `maxChassisAngularAcceleration` from the current 4π ≈ 12.57 rad/s². Based on the stator headroom during angular acceleration (~50% used at current limits), you could likely double the angular acceleration allowance before approaching motor limits. The practical ceiling is the direction-reversal case at ~70A stator — to stay safely below 100A, a 2–2.5× increase (to roughly 25–30 rad/s²) would be defensible from a current standpoint.