### PR TITLE
Fix Align Encoders trigger silently doing nothing

### DIFF
--- a/src/main/java/frc/lib/ControllerSelector.java
+++ b/src/main/java/frc/lib/ControllerSelector.java
@@ -2,7 +2,7 @@ package frc.lib;
 
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.GenericHID;
-import edu.wpi.first.wpilibj2.command.CommandScheduler;
+import edu.wpi.first.wpilibj.event.EventLoop;
 import frc.robot.Constants;
 import frc.robot.Constants.Mode;
 import java.util.Objects;
@@ -29,6 +29,11 @@ import org.littletonrobotics.junction.Logger;
  *
  * <p>2. Periodically call {@code ControllerSelector.getInstance().scan()} from a loop in your robot
  * code (e.g., using a Notifier or from {@code disabledPeriodic()}) to handle controller changes.
+ *
+ * <p>3. Call {@code ControllerSelector.getInstance().getBindingLoop().poll()} once per cycle (e.g.
+ * from {@code robotPeriodic()}) so that controller button bindings actually fire. This uses a
+ * dedicated EventLoop rather than the CommandScheduler's shared default button loop so that
+ * re-scanning never clears Triggers registered elsewhere in the robot code.
  */
 public class ControllerSelector {
 
@@ -44,12 +49,12 @@ public class ControllerSelector {
 
   @FunctionalInterface
   public interface DriverBinding {
-    DriverController bind(int port);
+    DriverController bind(int port, EventLoop loop);
   }
 
   @FunctionalInterface
   public interface OperatorBinding {
-    void bind(int port, DriverController driverController);
+    void bind(int port, DriverController driverController, EventLoop loop);
   }
 
   private static ControllerSelector instance;
@@ -178,7 +183,22 @@ public class ControllerSelector {
   private final GenericHID[] controllers;
   private final String[] controllerNames;
 
+  // Owns controller button bindings exclusively so that re-scanning (which clears and rebinds
+  // controls when the connected controllers change) never touches Triggers registered elsewhere
+  // in the robot code via the shared CommandScheduler default button loop.
+  private final EventLoop bindingLoop = new EventLoop();
+
   private DriverController activeDriverController = null;
+
+  /**
+   * Returns the EventLoop that controller button bindings are registered to. Must be polled once
+   * per cycle (e.g. from robotPeriodic()) for those bindings to take effect.
+   *
+   * @return The controller binding EventLoop.
+   */
+  public EventLoop getBindingLoop() {
+    return bindingLoop;
+  }
 
   /**
    * Constructs a new ControllerSelector object. This is private to enforce the singleton pattern.
@@ -258,8 +278,8 @@ public class ControllerSelector {
       return;
     }
 
-    // Clear all button bindings to prepare for rebinding
-    CommandScheduler.getInstance().getDefaultButtonLoop().clear();
+    // Clear controller button bindings to prepare for rebinding
+    bindingLoop.clear();
 
     int driverPort = -1;
     int operatorPort = -1;
@@ -285,7 +305,7 @@ public class ControllerSelector {
           driverPort = port;
           driverName = controllerName;
           driverType = config.controllerType.name();
-          DriverController driverController = config.driverBinding.bind(driverPort);
+          DriverController driverController = config.driverBinding.bind(driverPort, bindingLoop);
           activeDriverController = driverController;
           break; // Found a match, stop searching ports
         }
@@ -318,7 +338,7 @@ public class ControllerSelector {
           operatorPort = port;
           operatorName = controllerName;
           operatorType = config.controllerType.name();
-          config.operatorBinding.bind(operatorPort, activeDriverController);
+          config.operatorBinding.bind(operatorPort, activeDriverController, bindingLoop);
           break; // Found a match, stop searching ports
         }
       }

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -10,13 +10,13 @@ import edu.wpi.first.wpilibj.DriverStation.Alliance;
 import edu.wpi.first.wpilibj.PneumaticsModuleType;
 import edu.wpi.first.wpilibj.PowerDistribution.ModuleType;
 import edu.wpi.first.wpilibj.RobotBase;
+import edu.wpi.first.wpilibj.event.EventLoop;
 import edu.wpi.first.wpilibj.simulation.BatterySim;
 import edu.wpi.first.wpilibj.simulation.REVPHSim;
 import edu.wpi.first.wpilibj.simulation.RoboRioSim;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
 import edu.wpi.first.wpilibj2.command.Commands;
-import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.RunCommand;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import edu.wpi.first.wpilibj2.command.button.CommandGenericHID;
@@ -315,13 +315,6 @@ public class Robot extends LoggedRobot {
     CommandScheduler.getInstance().onCommandFinish(cmd -> activeCommands.remove(cmd.getName()));
     CommandScheduler.getInstance().onCommandInterrupt(cmd -> activeCommands.remove(cmd.getName()));
 
-    new Trigger(
-            NetworkTableInstance.getDefault()
-                    .getTable("Triggers")
-                    .getBooleanTopic("Align Encoders")
-                    .subscribe(false)
-                ::get)
-        .onTrue(new InstantCommand(drive::zeroAbsoluteEncoders).ignoringDisable(true));
     Field.plotRegions();
 
     feeder.setDefaultCommand(Commands.startEnd(feeder::stop, () -> {}, feeder).withName("Stop"));
@@ -347,6 +340,9 @@ public class Robot extends LoggedRobot {
     // This must be called from the robot's periodic block in order for anything in
     // the Command-based framework to work.
     CommandScheduler.getInstance().run();
+    // Controller button bindings live on their own EventLoop (see ControllerSelector) so that
+    // re-scanning for controller changes never clears Triggers registered elsewhere.
+    ControllerSelector.getInstance().getBindingLoop().poll();
     long t1 = FeatureFlags.PROFILING_ENABLED ? System.nanoTime() : 0;
 
     logCANBus("CAN2", Constants.CANBusPorts.CAN2.BUS);
@@ -503,7 +499,7 @@ public class Robot extends LoggedRobot {
         new DriverConfig(ControllerType.KEYBOARD, this::bindKeyboardDriver, Constants.Mode.SIM));
   }
 
-  public DriverController bindZorroDriver(int port) {
+  public DriverController bindZorroDriver(int port, EventLoop loop) {
     var zorroDriver = new CommandZorroController(port);
 
     var controller =
@@ -538,7 +534,7 @@ public class Robot extends LoggedRobot {
 
     // Reset gyro to 0° when button G is pressed
     zorroDriver
-        .GIn()
+        .GIn(loop)
         .onTrue(
             Commands.runOnce(() -> DriveCommands.resetDriverForward(drive)).ignoringDisable(true));
 
@@ -547,7 +543,7 @@ public class Robot extends LoggedRobot {
     // requires hopper and will interrupt whatever is currently running on that subsystem.
     if (FeatureFlags.HOPPER_ENABLED)
       zorroDriver
-          .DIn()
+          .DIn(loop)
           .onTrue(
               Commands.runOnce(
                   () ->
@@ -555,10 +551,11 @@ public class Robot extends LoggedRobot {
                           .schedule()));
 
     // Desaturate turret and advance feeder
-    zorroDriver.AIn().whileTrue(createDesaturateAndShootCommand(controller));
+    zorroDriver.AIn(loop).whileTrue(createDesaturateAndShootCommand(controller));
 
     // Launcher
-    Trigger launcherEnabled = zorroDriver.axisGreaterThan(Axis.kLeftDial.value, 0.5).debounce(0.1);
+    Trigger launcherEnabled =
+        zorroDriver.axisGreaterThan(Axis.kLeftDial.value, 0.5, loop).debounce(0.1);
     launcherEnabled
         .or(() -> DriverStation.isFMSAttached())
         .whileTrue(
@@ -572,12 +569,12 @@ public class Robot extends LoggedRobot {
                         .withName("Aim at hub")));
 
     // Intake
-    zorroDriver.HIn().whileTrue(intake.getDeployCommand());
+    zorroDriver.HIn(loop).whileTrue(intake.getDeployCommand());
 
     return controller;
   }
 
-  public DriverController bindXboxDriver(int port) {
+  public DriverController bindXboxDriver(int port, EventLoop loop) {
     var xboxDriver = new CommandXboxController(port);
 
     var controller =
@@ -612,7 +609,7 @@ public class Robot extends LoggedRobot {
 
     // Reset gyro to 0° when B button is pressed
     xboxDriver
-        .b()
+        .b(loop)
         .onTrue(
             Commands.runOnce(() -> DriveCommands.resetDriverForward(drive)).ignoringDisable(true));
 
@@ -682,15 +679,15 @@ public class Robot extends LoggedRobot {
     // xboxDriver.x().onTrue(Commands.runOnce(drive::stopWithX, drive));
 
     // Desaturate turret and advance feeder
-    xboxDriver.a().whileTrue(createDesaturateAndShootCommand(controller));
+    xboxDriver.a(loop).whileTrue(createDesaturateAndShootCommand(controller));
 
     // Intake
-    xboxDriver.rightBumper().whileTrue(intake.getDeployCommand());
+    xboxDriver.rightBumper(loop).whileTrue(intake.getDeployCommand());
 
     return controller;
   }
 
-  public DriverController bindKeyboardDriver(int port) {
+  public DriverController bindKeyboardDriver(int port, EventLoop loop) {
     var keyboard = new CommandGenericHID(port);
 
     // WPILib sim keyboard axis layout:
@@ -729,30 +726,30 @@ public class Robot extends LoggedRobot {
 
     // Reset heading to 0° when Z (button 1) is pressed
     keyboard
-        .button(1)
+        .button(1, loop)
         .onTrue(
             Commands.runOnce(() -> DriveCommands.resetDriverForward(drive)).ignoringDisable(true));
 
     return controller;
   }
 
-  public void bindXboxOperator(int port, DriverController driver) {
+  public void bindXboxOperator(int port, DriverController driver, EventLoop loop) {
     var xboxOperator = new CommandXboxController(port);
 
     // Intake
-    xboxOperator.b().whileTrue(intake.getDeployCommand());
-    // xboxOperator.b().and(() -> hopper.isDeployed()).whileTrue(intake.getDeployCommand());
+    xboxOperator.b(loop).whileTrue(intake.getDeployCommand());
+    // xboxOperator.b(loop).and(() -> hopper.isDeployed()).whileTrue(intake.getDeployCommand());
 
-    xboxOperator.y().whileTrue(intake.getReverseCommand());
-    // xboxOperator.y().and(() -> hopper.isDeployed()).whileTrue(intake.getReverseCommand());
+    xboxOperator.y(loop).whileTrue(intake.getReverseCommand());
+    // xboxOperator.y(loop).and(() -> hopper.isDeployed()).whileTrue(intake.getReverseCommand());
 
     // Feeder
-    xboxOperator.a().whileTrue(feeder.getSpinForwardCommand());
+    xboxOperator.a(loop).whileTrue(feeder.getSpinForwardCommand());
 
-    xboxOperator.x().whileTrue(feeder.getReverseCommand());
+    xboxOperator.x(loop).whileTrue(feeder.getReverseCommand());
 
     // Desaturate turret and advance feeder
-    xboxOperator.rightBumper().whileTrue(createDesaturateAndShootCommand(driver));
+    xboxOperator.rightBumper(loop).whileTrue(createDesaturateAndShootCommand(driver));
   }
 
   public void configureAutoOptions() {

--- a/src/main/java/frc/robot/subsystems/drive/Drive.java
+++ b/src/main/java/frc/robot/subsystems/drive/Drive.java
@@ -38,13 +38,17 @@ import edu.wpi.first.math.kinematics.SwerveModulePosition;
 import edu.wpi.first.math.kinematics.SwerveModuleState;
 import edu.wpi.first.math.numbers.N1;
 import edu.wpi.first.math.numbers.N3;
+import edu.wpi.first.networktables.BooleanPublisher;
+import edu.wpi.first.networktables.NetworkTableInstance;
 import edu.wpi.first.wpilibj.Alert;
 import edu.wpi.first.wpilibj.Alert.AlertType;
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.DriverStation.Alliance;
 import edu.wpi.first.wpilibj.RobotState;
 import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
+import edu.wpi.first.wpilibj2.command.button.Trigger;
 import edu.wpi.first.wpilibj2.command.sysid.SysIdRoutine;
 import frc.robot.Constants;
 import frc.robot.Constants.FeatureFlags;
@@ -66,6 +70,7 @@ public class Drive extends SubsystemBase {
   private final SysIdRoutine sysId;
   private final Alert gyroDisconnectedAlert =
       new Alert("Disconnected gyro, using kinematics as fallback.", AlertType.kError);
+  private final BooleanPublisher alignEncodersPub;
 
   private SwerveDriveKinematics kinematics = new SwerveDriveKinematics(MODULE_TRANSLATIONS);
   private Rotation2d rawGyroRotation = Rotation2d.kZero;
@@ -150,6 +155,14 @@ public class Drive extends SubsystemBase {
                 (voltage) -> runCharacterization(voltage.in(Volts)), null, this));
 
     headingController.enableContinuousInput(-Math.PI, Math.PI);
+
+    var alignEncodersTopic =
+        NetworkTableInstance.getDefault().getTable("Triggers").getBooleanTopic("Align Encoders");
+    var alignEncodersSub = alignEncodersTopic.subscribe(false);
+    alignEncodersPub = alignEncodersTopic.publish();
+    alignEncodersPub.set(false);
+    new Trigger(alignEncodersSub::get)
+        .onTrue(Commands.runOnce(this::zeroAbsoluteEncoders, this).ignoringDisable(true));
   }
 
   @Override
@@ -445,5 +458,6 @@ public class Drive extends SubsystemBase {
     for (var module : modules) {
       module.setTurnZero();
     }
+    alignEncodersPub.set(false);
   }
 }


### PR DESCRIPTION
## Summary
- Move the `Triggers/Align Encoders` NT trigger from `Robot.java` into `Drive.java`, requiring the `Drive` subsystem and resetting the boolean back to `false` after zeroing, matching Biocore's implementation.
- Fix the actual root cause: `ControllerSelector.scan()` called `CommandScheduler.getInstance().getDefaultButtonLoop().clear()` to rebind controller controls, which silently wiped out *any* `Trigger` registered on that shared default loop before `ControllerSelector` ran — including Align Encoders. `ControllerSelector` now owns a private `EventLoop` for its own bindings, polled explicitly from `robotPeriodic()`, so re-scanning never touches Triggers registered elsewhere. Ported from Biocore commit `0b07ed7`.

## Test plan
- [x] `./gradlew compileJava compileTestJava` passes clean
- [x] Deploy to the robot and confirm toggling `Triggers/Align Encoders` to `true` in Glass actually zeros the swerve encoders and the boolean pops back to `false`
- [x] Confirm driver/operator controller bindings (Zorro, Xbox driver, keyboard, Xbox operator) still fire normally after a controller reconnect/rescan

🤖 Generated with [Claude Code](https://claude.com/claude-code)