### PR TITLE
Fix turret setpoint wraparound for asymmetric operating ranges

### DIFF
--- a/src/main/java/frc/robot/subsystems/launcher/LauncherConstants.java
+++ b/src/main/java/frc/robot/subsystems/launcher/LauncherConstants.java
@@ -77,7 +77,6 @@ public final class LauncherConstants {
     public static final Transform3d CHASSIS_TO_TURRET_BASE =
         new Transform3d(Inches.of(-4.000), Inches.of(6.500), Inches.of(16.331), Rotation3d.kZero);
     public static final Rotation2d ABS_ENCODER_OFFSET = new Rotation2d(5.157 + 1.267);
-    public static final Rotation2d MECHANISM_OFFSET = Rotation2d.kZero;
     public static final double UPPER_LIMIT_RAD = Units.degreesToRadians(30);
     public static final double LOWER_LIMIT_RAD = Units.degreesToRadians(-280);
     public static final double CENTER_RAD = (LOWER_LIMIT_RAD + UPPER_LIMIT_RAD) / 2.0;

--- a/src/main/java/frc/robot/subsystems/launcher/LauncherConstants.java
+++ b/src/main/java/frc/robot/subsystems/launcher/LauncherConstants.java
@@ -80,6 +80,7 @@ public final class LauncherConstants {
     public static final Rotation2d MECHANISM_OFFSET = Rotation2d.kZero;
     public static final double UPPER_LIMIT_RAD = Units.degreesToRadians(30);
     public static final double LOWER_LIMIT_RAD = Units.degreesToRadians(-280);
+    public static final double CENTER_RAD = (LOWER_LIMIT_RAD + UPPER_LIMIT_RAD) / 2.0;
     public static final double MARGIN_RAD = Units.degreesToRadians(5);
 
     // Position controller

--- a/src/main/java/frc/robot/subsystems/launcher/LauncherConstants.java
+++ b/src/main/java/frc/robot/subsystems/launcher/LauncherConstants.java
@@ -78,8 +78,8 @@ public final class LauncherConstants {
         new Transform3d(Inches.of(-4.000), Inches.of(6.500), Inches.of(16.331), Rotation3d.kZero);
     public static final Rotation2d ABS_ENCODER_OFFSET = new Rotation2d(5.157 + 1.267);
     public static final Rotation2d MECHANISM_OFFSET = Rotation2d.kZero;
-    public static final double UPPER_LIMIT_RAD = Units.degreesToRadians(100);
-    public static final double LOWER_LIMIT_RAD = Units.degreesToRadians(-10);
+    public static final double UPPER_LIMIT_RAD = Units.degreesToRadians(0);
+    public static final double LOWER_LIMIT_RAD = Units.degreesToRadians(-45);
     public static final double MARGIN_RAD = Units.degreesToRadians(5);
 
     // Position controller

--- a/src/main/java/frc/robot/subsystems/launcher/LauncherConstants.java
+++ b/src/main/java/frc/robot/subsystems/launcher/LauncherConstants.java
@@ -76,9 +76,26 @@ public final class LauncherConstants {
     // Geometry
     public static final Transform3d CHASSIS_TO_TURRET_BASE =
         new Transform3d(Inches.of(-4.000), Inches.of(6.500), Inches.of(16.331), Rotation3d.kZero);
+    // Turret angle convention: 0 / 2*pi rad = forward, increasing CCW (viewed from above),
+    // matching standard Rotation2d/WPILib handedness. All constants below are w/r/t forward.
+
+    // Calibration value chosen so the absolute encoder reads 0 / 2*pi when the turret is
+    // physically facing forward. To reclock after a mechanical rebuild or encoder reseat: point
+    // the turret forward by hand, read the raw absolute encoder value (with this offset backed
+    // out, i.e. temporarily zeroed), and set ABS_ENCODER_OFFSET to that raw reading.
     public static final Rotation2d ABS_ENCODER_OFFSET = new Rotation2d(5.157 + 1.267);
+
+    // Soft limits of the mechanical range, measured CCW from forward (e.g. LOWER=-280 means the
+    // turret can travel 280 deg clockwise of forward). UPPER_LIMIT_RAD - LOWER_LIMIT_RAD must
+    // stay under 360 deg, or the wrap math below (CENTER_RAD, and its use in TurretIOSpark /
+    // TurretIOSimSpark) can no longer place every reachable angle in a single unambiguous branch.
     public static final double UPPER_LIMIT_RAD = Units.degreesToRadians(30);
     public static final double LOWER_LIMIT_RAD = Units.degreesToRadians(-280);
+
+    // Center of the operating range. Used to pick the modulus window ([CENTER-pi, CENTER+pi))
+    // that setpoints and the relative-encoder seed get wrapped into, so the branch cut always
+    // falls in the unreachable gap directly opposite the range rather than inside it. Derived
+    // automatically from the limits above - do not hand-edit when reclocking.
     public static final double CENTER_RAD = (LOWER_LIMIT_RAD + UPPER_LIMIT_RAD) / 2.0;
     public static final double MARGIN_RAD = Units.degreesToRadians(5);
 

--- a/src/main/java/frc/robot/subsystems/launcher/LauncherConstants.java
+++ b/src/main/java/frc/robot/subsystems/launcher/LauncherConstants.java
@@ -76,10 +76,10 @@ public final class LauncherConstants {
     // Geometry
     public static final Transform3d CHASSIS_TO_TURRET_BASE =
         new Transform3d(Inches.of(-4.000), Inches.of(6.500), Inches.of(16.331), Rotation3d.kZero);
-    public static final Rotation2d ABS_ENCODER_OFFSET = new Rotation2d(5.157);
+    public static final Rotation2d ABS_ENCODER_OFFSET = new Rotation2d(5.157 + 1.267);
     public static final Rotation2d MECHANISM_OFFSET = Rotation2d.kZero;
-    public static final double UPPER_LIMIT_RAD = Units.degreesToRadians(270);
-    public static final double LOWER_LIMIT_RAD = Units.degreesToRadians(45);
+    public static final double UPPER_LIMIT_RAD = Units.degreesToRadians(100);
+    public static final double LOWER_LIMIT_RAD = Units.degreesToRadians(-10);
     public static final double MARGIN_RAD = Units.degreesToRadians(5);
 
     // Position controller

--- a/src/main/java/frc/robot/subsystems/launcher/LauncherConstants.java
+++ b/src/main/java/frc/robot/subsystems/launcher/LauncherConstants.java
@@ -78,8 +78,8 @@ public final class LauncherConstants {
         new Transform3d(Inches.of(-4.000), Inches.of(6.500), Inches.of(16.331), Rotation3d.kZero);
     public static final Rotation2d ABS_ENCODER_OFFSET = new Rotation2d(5.157 + 1.267);
     public static final Rotation2d MECHANISM_OFFSET = Rotation2d.kZero;
-    public static final double UPPER_LIMIT_RAD = Units.degreesToRadians(0);
-    public static final double LOWER_LIMIT_RAD = Units.degreesToRadians(-45);
+    public static final double UPPER_LIMIT_RAD = Units.degreesToRadians(30);
+    public static final double LOWER_LIMIT_RAD = Units.degreesToRadians(-280);
     public static final double MARGIN_RAD = Units.degreesToRadians(5);
 
     // Position controller

--- a/src/main/java/frc/robot/subsystems/launcher/TurretIOSimSpark.java
+++ b/src/main/java/frc/robot/subsystems/launcher/TurretIOSimSpark.java
@@ -79,8 +79,7 @@ public class TurretIOSimSpark implements TurretIO {
             GEARBOX);
 
     double seedPosition =
-        MathUtil.inputModulus(
-            2.0 * Math.PI - MECHANISM_OFFSET.getRadians(), CENTER_RAD - Math.PI, CENTER_RAD + Math.PI);
+        MathUtil.inputModulus(2.0 * Math.PI, CENTER_RAD - Math.PI, CENTER_RAD + Math.PI);
     turnSim.setState(seedPosition, 0);
     turnSparkSim.setPosition(turnSim.getAngularPositionRad());
   }
@@ -96,13 +95,13 @@ public class TurretIOSimSpark implements TurretIO {
 
     // Update inputs
     inputs.motorControllerConnected = true;
-    inputs.relativePosition = new Rotation2d(turnSparkSim.getPosition()).plus(MECHANISM_OFFSET);
+    inputs.relativePosition = new Rotation2d(turnSparkSim.getPosition());
     inputs.velocityRadPerSec = turnSparkSim.getVelocity();
     inputs.appliedVolts = turnSparkSim.getAppliedOutput() * turnSparkSim.getBusVoltage();
     inputs.currentAmps = Math.abs(turnSparkSim.getMotorCurrent());
 
     inputs.absoluteEncoderConnected = true;
-    inputs.absolutePosition = new Rotation2d(turnSparkSim.getPosition()).plus(MECHANISM_OFFSET);
+    inputs.absolutePosition = new Rotation2d(turnSparkSim.getPosition());
 
     inputs.oversaturation = oversaturation;
     inputs.oversaturationLessMargin = oversaturationLessMargin;
@@ -118,10 +117,7 @@ public class TurretIOSimSpark implements TurretIO {
   @Override
   public void setPosition(Rotation2d rotation, AngularVelocity angularVelocity) {
     double setpoint =
-        MathUtil.inputModulus(
-            rotation.getRadians() - MECHANISM_OFFSET.getRadians(),
-            CENTER_RAD - Math.PI,
-            CENTER_RAD + Math.PI);
+        MathUtil.inputModulus(rotation.getRadians(), CENTER_RAD - Math.PI, CENTER_RAD + Math.PI);
     double clampedSetpoint = MathUtil.clamp(setpoint, LOWER_LIMIT_RAD, UPPER_LIMIT_RAD);
     double clampedSetpointWithMargin =
         MathUtil.clamp(setpoint, LOWER_LIMIT_RAD + MARGIN_RAD, UPPER_LIMIT_RAD - MARGIN_RAD);

--- a/src/main/java/frc/robot/subsystems/launcher/TurretIOSimSpark.java
+++ b/src/main/java/frc/robot/subsystems/launcher/TurretIOSimSpark.java
@@ -78,7 +78,10 @@ public class TurretIOSimSpark implements TurretIO {
             LinearSystemId.createDCMotorSystem(GEARBOX, TURRET_MOI_KG_M2, MOTOR_REDUCTION),
             GEARBOX);
 
-    turnSim.setState(2.0 * Math.PI - MECHANISM_OFFSET.getRadians(), 0);
+    double seedPosition =
+        MathUtil.inputModulus(
+            2.0 * Math.PI - MECHANISM_OFFSET.getRadians(), CENTER_RAD - Math.PI, CENTER_RAD + Math.PI);
+    turnSim.setState(seedPosition, 0);
     turnSparkSim.setPosition(turnSim.getAngularPositionRad());
   }
 
@@ -116,7 +119,9 @@ public class TurretIOSimSpark implements TurretIO {
   public void setPosition(Rotation2d rotation, AngularVelocity angularVelocity) {
     double setpoint =
         MathUtil.inputModulus(
-            rotation.getRadians() - MECHANISM_OFFSET.getRadians(), 0.0, 2.0 * Math.PI);
+            rotation.getRadians() - MECHANISM_OFFSET.getRadians(),
+            CENTER_RAD - Math.PI,
+            CENTER_RAD + Math.PI);
     double clampedSetpoint = MathUtil.clamp(setpoint, LOWER_LIMIT_RAD, UPPER_LIMIT_RAD);
     double clampedSetpointWithMargin =
         MathUtil.clamp(setpoint, LOWER_LIMIT_RAD + MARGIN_RAD, UPPER_LIMIT_RAD - MARGIN_RAD);

--- a/src/main/java/frc/robot/subsystems/launcher/TurretIOSpark.java
+++ b/src/main/java/frc/robot/subsystems/launcher/TurretIOSpark.java
@@ -98,12 +98,11 @@ public class TurretIOSpark implements TurretIO {
   @Override
   public void updateInputs(TurretIOInputs inputs) {
     if (!relativeEncoderSeeded && inputs.absoluteEncoderConnected) {
-      double center = (LOWER_LIMIT_RAD + UPPER_LIMIT_RAD) / 2.0;
       double seedPosition =
           MathUtil.inputModulus(
               absoluteEncoder.get() - MECHANISM_OFFSET.getRadians(),
-              center - Math.PI,
-              center + Math.PI);
+              CENTER_RAD - Math.PI,
+              CENTER_RAD + Math.PI);
       turnSparkEncoder.setPosition(seedPosition);
       relativeEncoderSeeded = true;
     }
@@ -134,12 +133,11 @@ public class TurretIOSpark implements TurretIO {
 
   @Override
   public void setPosition(Rotation2d rotation, AngularVelocity angularVelocity) {
-    double center = (LOWER_LIMIT_RAD + UPPER_LIMIT_RAD) / 2.0;
     double setpoint =
         MathUtil.inputModulus(
             rotation.getRadians() - MECHANISM_OFFSET.getRadians(),
-            center - Math.PI,
-            center + Math.PI);
+            CENTER_RAD - Math.PI,
+            CENTER_RAD + Math.PI);
     double clampedSetpoint = MathUtil.clamp(setpoint, LOWER_LIMIT_RAD, UPPER_LIMIT_RAD);
     double clampedSetpointWithMargin =
         MathUtil.clamp(setpoint, LOWER_LIMIT_RAD + MARGIN_RAD, UPPER_LIMIT_RAD - MARGIN_RAD);

--- a/src/main/java/frc/robot/subsystems/launcher/TurretIOSpark.java
+++ b/src/main/java/frc/robot/subsystems/launcher/TurretIOSpark.java
@@ -98,7 +98,13 @@ public class TurretIOSpark implements TurretIO {
   @Override
   public void updateInputs(TurretIOInputs inputs) {
     if (!relativeEncoderSeeded && inputs.absoluteEncoderConnected) {
-      turnSparkEncoder.setPosition(absoluteEncoder.get());
+      double center = (LOWER_LIMIT_RAD + UPPER_LIMIT_RAD) / 2.0;
+      double seedPosition =
+          MathUtil.inputModulus(
+              absoluteEncoder.get() - MECHANISM_OFFSET.getRadians(),
+              center - Math.PI,
+              center + Math.PI);
+      turnSparkEncoder.setPosition(seedPosition);
       relativeEncoderSeeded = true;
     }
 

--- a/src/main/java/frc/robot/subsystems/launcher/TurretIOSpark.java
+++ b/src/main/java/frc/robot/subsystems/launcher/TurretIOSpark.java
@@ -54,7 +54,7 @@ public class TurretIOSpark implements TurretIO {
         new DutyCycleEncoder(
             new DigitalInput(DIOPorts.TURRET_ABS_ENCODER),
             2 * Math.PI,
-            ABS_ENCODER_OFFSET.getRadians() + MECHANISM_OFFSET.getRadians());
+            ABS_ENCODER_OFFSET.getRadians());
 
     var turnConfig = new SparkMaxConfig();
 
@@ -99,16 +99,13 @@ public class TurretIOSpark implements TurretIO {
   public void updateInputs(TurretIOInputs inputs) {
     if (!relativeEncoderSeeded && inputs.absoluteEncoderConnected) {
       double seedPosition =
-          MathUtil.inputModulus(
-              absoluteEncoder.get() - MECHANISM_OFFSET.getRadians(),
-              CENTER_RAD - Math.PI,
-              CENTER_RAD + Math.PI);
+          MathUtil.inputModulus(absoluteEncoder.get(), CENTER_RAD - Math.PI, CENTER_RAD + Math.PI);
       turnSparkEncoder.setPosition(seedPosition);
       relativeEncoderSeeded = true;
     }
 
     // Read from cached values (non-blocking) - updated by SparkOdometryThread
-    inputs.relativePosition = new Rotation2d(sparkInputs.getPosition()).plus(MECHANISM_OFFSET);
+    inputs.relativePosition = new Rotation2d(sparkInputs.getPosition());
     inputs.velocityRadPerSec = sparkInputs.getVelocity();
     inputs.appliedVolts = sparkInputs.getAppliedVolts();
     inputs.currentAmps = sparkInputs.getOutputCurrent();
@@ -134,10 +131,7 @@ public class TurretIOSpark implements TurretIO {
   @Override
   public void setPosition(Rotation2d rotation, AngularVelocity angularVelocity) {
     double setpoint =
-        MathUtil.inputModulus(
-            rotation.getRadians() - MECHANISM_OFFSET.getRadians(),
-            CENTER_RAD - Math.PI,
-            CENTER_RAD + Math.PI);
+        MathUtil.inputModulus(rotation.getRadians(), CENTER_RAD - Math.PI, CENTER_RAD + Math.PI);
     double clampedSetpoint = MathUtil.clamp(setpoint, LOWER_LIMIT_RAD, UPPER_LIMIT_RAD);
     double clampedSetpointWithMargin =
         MathUtil.clamp(setpoint, LOWER_LIMIT_RAD + MARGIN_RAD, UPPER_LIMIT_RAD - MARGIN_RAD);

--- a/src/main/java/frc/robot/subsystems/launcher/TurretIOSpark.java
+++ b/src/main/java/frc/robot/subsystems/launcher/TurretIOSpark.java
@@ -128,9 +128,12 @@ public class TurretIOSpark implements TurretIO {
 
   @Override
   public void setPosition(Rotation2d rotation, AngularVelocity angularVelocity) {
+    double center = (LOWER_LIMIT_RAD + UPPER_LIMIT_RAD) / 2.0;
     double setpoint =
         MathUtil.inputModulus(
-            rotation.getRadians() - MECHANISM_OFFSET.getRadians(), 0.0, 2 * Math.PI);
+            rotation.getRadians() - MECHANISM_OFFSET.getRadians(),
+            center - Math.PI,
+            center + Math.PI);
     double clampedSetpoint = MathUtil.clamp(setpoint, LOWER_LIMIT_RAD, UPPER_LIMIT_RAD);
     double clampedSetpointWithMargin =
         MathUtil.clamp(setpoint, LOWER_LIMIT_RAD + MARGIN_RAD, UPPER_LIMIT_RAD - MARGIN_RAD);


### PR DESCRIPTION
## Summary
- Fixes the turret's closed-loop position wrap/clamp so it works correctly for operating ranges that don't start at 0 deg (e.g. `-280 deg` to `30 deg`). The old `inputModulus(x, 0, 2*pi)` folded any negative setpoint onto the same clamped value, and the one-time relative-encoder seed could land in a different 2*pi epoch than the commanded setpoints, both of which caused the turret to take the long way around (up to a full extra revolution) instead of the short path to target.
- Extracts the wrap-window center into a `CENTER_RAD` constant shared between `TurretIOSpark` and `TurretIOSimSpark`, and brings the sim IO (previously still on the old `[0, 2*pi)` wrap) in line with the real one.
- Removes `MECHANISM_OFFSET`, a second always-zero rotation offset that duplicated `ABS_ENCODER_OFFSET`'s job and, if ever set nonzero, would have silently shifted the soft limits away from true forward without affecting reported position - a hazard with no upside.
- Documents the turret's angle convention, what `ABS_ENCODER_OFFSET` calibrates and how to redo it, and the constraint the operating range must satisfy, so future reclocking doesn't require re-deriving this from the control math.
- Also includes prior commits on this branch: seeding the turret's relative encoder from the absolute encoder on boot, several rounds of soft-limit tuning from bench testing, and a driver-controller-selection cleanup.

## Test plan
- [x] Verified against real robot logs (sessions 91-95): confirmed the pre-fix encoder-seed epoch mismatch caused a ~343 deg runaway sweep, confirmed it's gone after the fix, and confirmed the wrap math holds for the widened `-280/30` range with no phantom encoder jumps.
- [ ] Bench-test the current `-280 deg` to `30 deg` range end-to-end once the reported mechanical binding is resolved.
- [ ] Confirm sim (`TurretIOSimSpark`) still initializes and tracks correctly with the centered wrap window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)